### PR TITLE
Improve module sizing

### DIFF
--- a/MMM-DailyBibleVerse.css
+++ b/MMM-DailyBibleVerse.css
@@ -1,0 +1,23 @@
+.MMM-DailyBibleVerse {
+    max-width: 100vh;
+    height: auto;
+    max-height: auto;
+    line-height: 1em;
+}
+
+.MMM-DailyBibleVerse .xsmall,
+.MMM-DailyBibleVerse .default {
+    max-width: 50vh;
+}
+
+.MMM-DailyBibleVerse .small {
+    max-width: 60vh;
+}
+
+.MMM-DailyBibleVerse .medium {
+    max-width: 75vh;
+}
+
+.MMM-DailyBibleVerse .large {
+    max-width: 100vh;
+}

--- a/MMM-DailyBibleVerse.js
+++ b/MMM-DailyBibleVerse.js
@@ -25,6 +25,10 @@ Module.register("MMM-DailyBibleVerse", {
         }, 3600000); //perform every hour (3600000 milliseconds)
     },
 
+    getStyles: function () {
+        return ["MMM-DailyBibleVerse.css"];
+    },
+
     // Override dom generator.
     getDom: function() {
         Log.log("Updating MMM-DailyBibleVerse DOM.");
@@ -55,13 +59,13 @@ Module.register("MMM-DailyBibleVerse", {
                 wrapper.className = "bright small";
                 break;
             case 'medium':
-                wrapper.className = "bright";
+                wrapper.className = "bright medium";
                 break;
             case 'large':
                 wrapper.className = "bright large";
                 break;
             default:
-                wrapper.className = "bright";
+                wrapper.className = "bright medium";
         }
         wrapper.innerHTML = verse + reference;
         return wrapper;


### PR DESCRIPTION
As MagicMirror lets modules overflow their space, this module, when configured in other places different that the top and bottom bars, overflowed everywhere, causing a chaos :)

**Changes**
- This module's max-width will never be greater than the maximum one designated for each [region](https://forum.magicmirror.builders/topic/286/regions). This is scalable to whatever resolution the user is using
- If no size is specified, the module will use the ``medium`` size,as it makles sense as it's somehow the same size that most modules use

**Screenshots**

Here are some screenshots from the module positioned in ``top_right``

## XSmall
![xsmall](https://user-images.githubusercontent.com/10274099/79274592-18437880-7ea5-11ea-83e1-4881b14f3e18.png)

## Small
![small](https://user-images.githubusercontent.com/10274099/79274568-0c57b680-7ea5-11ea-804d-cf0849d25b05.png)

## Medium
![medium](https://user-images.githubusercontent.com/10274099/79274618-1e395980-7ea5-11ea-9e3f-7410f9b8e464.png)

## Large
![large](https://user-images.githubusercontent.com/10274099/79274627-22657700-7ea5-11ea-9a42-af99e003376d.png)

As you can see, the sizes are very similar to the previous sizes, but they are scaled properly.

## Before this PR
Screenshot in ``top_right```and without a size specified and without other modules:

![image](https://user-images.githubusercontent.com/10274099/79274805-69ec0300-7ea5-11ea-8076-465f94707eff.png)

Same as above but with a module in ``top_left``. Notice how the ``top_left`` module is completely covered by this one:

![image](https://user-images.githubusercontent.com/10274099/79274976-a7509080-7ea5-11ea-92e1-f5572f353235.png)
